### PR TITLE
Added a suggested kmer length

### DIFF
--- a/image/Taskfile
+++ b/image/Taskfile
@@ -1,1 +1,1 @@
-default: tadpole.sh in=${READS} out=${CONTIGS}
+default: tadpole.sh in=${READS} out=${CONTIGS} k=75


### PR DESCRIPTION
"k=93" will give a much better assembly in most cases, using 150 bp reads.  For 100 bp reads (which are quite common), k=75 is probably a better default.  For an arbitrary read length, tadwrapper will suggest an optimal kmer length...

It would probably be best if kmer length were a variable, defaulting to 75 when unspecified.  I suppose that would require some conditionals when parsing the parameters.
